### PR TITLE
v0.1.9: Add a TCP load generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "ort-core",
  "ort-grpc",
  "ort-http",
+ "ort-tcp",
  "rand",
  "regex",
  "serde",
@@ -799,9 +800,9 @@ dependencies = [
 name = "ort-tcp"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "futures",
- "hyper",
  "ort-core",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "ort"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "num_cpus",
  "ort-load",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "ort-load"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "futures",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "ort-server"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ name = "ort-load"
 version = "0.1.8"
 dependencies = [
  "async-trait",
+ "futures",
  "hdrhistogram",
  "hyper",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,9 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -241,12 +244,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -254,6 +273,35 @@ name = "futures-core"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -266,6 +314,9 @@ name = "futures-task"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
@@ -273,10 +324,18 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project 1.0.1",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -640,6 +699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+
+[[package]]
 name = "ort"
 version = "0.1.8"
 dependencies = [
@@ -658,6 +723,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "serde",
 ]
 
 [[package]]
@@ -721,10 +787,27 @@ dependencies = [
  "ort-core",
  "ort-grpc",
  "ort-http",
+ "ort-tcp",
  "rand",
  "structopt",
  "tokio",
  "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "ort-tcp"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "hyper",
+ "ort-core",
+ "rand",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -825,6 +908,18 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "ort"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Oliver Gould <ver@buoyant.io>"]
 edition = "2018"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "http",
     "load",
     "server",
+    "tcp",
 ]
 
 [package]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ort
 description: Multi-protocol load generator
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: 0.7.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The project consists of a client and server that are ready to be deployed in
 Kubernetes, especially for testing [Linkerd](https://linkerd.io).
 
 ```
-ort 0.1.8
+ort 0.1.9
 Load harness
 
 USAGE:

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,10 +5,14 @@ authors = ["Oliver Gould <ver@buoyant.io>"]
 edition = "2018"
 publish = false
 
+[features]
+deser = ["serde", "bytes/serde"]
+
 [dependencies]
 bytes = "0.5"
 async-trait = "0.1"
 #rand = { version = "0.7", features = ["small_rng"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 #tokio = { version = "0.2", features = ["time"] }
 #tokio-compat-02 = "0.1"
 #tracing = "0.1"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,6 +18,7 @@ pub trait Ort: Clone + Send + 'static {
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "deser", derive(serde::Serialize, serde::Deserialize))]
 pub struct Spec {
     pub latency: Duration,
     pub response_size: usize,
@@ -25,6 +26,7 @@ pub struct Spec {
 }
 
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "deser", derive(serde::Serialize, serde::Deserialize))]
 pub struct Reply {
     pub data: Bytes,
 }

--- a/load/Cargo.toml
+++ b/load/Cargo.toml
@@ -10,6 +10,7 @@ grpc-fmt = ["ort-grpc/rustfmt"]
 
 [dependencies]
 async-trait = "0.1"
+futures = "0.3"
 hdrhistogram = "7.1"
 hyper = "0.13.3"
 indexmap = "1.0"

--- a/load/Cargo.toml
+++ b/load/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ort-load"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Oliver Gould <ver@buoyant.io>"]
 edition = "2018"
 publish = false

--- a/load/Cargo.toml
+++ b/load/Cargo.toml
@@ -16,6 +16,7 @@ indexmap = "1.0"
 ort-core = { path = "../core" }
 ort-grpc = { path = "../grpc" }
 ort-http = { path = "../http" }
+ort-tcp = { path = "../tcp" }
 rand = { version = "0.7", features = ["small_rng"] }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/load/src/lib.rs
+++ b/load/src/lib.rs
@@ -116,7 +116,9 @@ impl Cmd {
 
         let limit = (
             Arc::new(Semaphore::new(
-                concurrency_limit.filter(|c| *c > 0).unwrap_or(clients_per_target),
+                concurrency_limit
+                    .filter(|c| *c > 0)
+                    .unwrap_or(clients_per_target),
             )),
             RateLimit::spawn(request_limit, request_limit_window),
         );

--- a/load/src/lib.rs
+++ b/load/src/lib.rs
@@ -17,6 +17,7 @@ use self::{
 use ort_core::{Error, MakeOrt, Ort, Reply, Spec};
 use ort_grpc::client::MakeGrpc;
 use ort_http::client::MakeHttp;
+use ort_tcp::client::MakeTcp;
 use rand::{rngs::SmallRng, SeedableRng};
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
 use structopt::StructOpt;
@@ -72,12 +73,13 @@ pub struct Opt {
     targets: Vec<Target>,
 }
 
-type Target = Flavor<hyper::Uri, hyper::Uri>;
+type Target = Flavor<hyper::Uri, hyper::Uri, String>;
 
 #[derive(Clone, Debug)]
-pub enum Flavor<H, G> {
+pub enum Flavor<H, G, T> {
     Http(H),
     Grpc(G),
+    Tcp(T),
 }
 
 // === impl Load ===C
@@ -121,7 +123,8 @@ impl Opt {
         let connect = {
             let http = MakeHttp::new(connect_timeout, http_close);
             let grpc = MakeGrpc::new(connect_timeout, Duration::from_secs(1));
-            let timeout = MakeRequestTimeout::new((http, grpc), request_timeout);
+            let tcp = MakeTcp::new();
+            let timeout = MakeRequestTimeout::new((http, grpc, tcp), request_timeout);
             MakeMetrics::new(timeout, histogram)
         };
 
@@ -151,14 +154,16 @@ impl Opt {
 // === impl Flavor ===
 
 #[async_trait::async_trait]
-impl<H, G> MakeOrt<Target> for (H, G)
+impl<H, G, T> MakeOrt<Target> for (H, G, T)
 where
     H: MakeOrt<hyper::Uri> + Send + Sync + 'static,
     H::Ort: Send + Sync + 'static,
     G: MakeOrt<hyper::Uri> + Send + Sync + 'static,
     G::Ort: Send + Sync + 'static,
+    T: MakeOrt<String> + Send + Sync + 'static,
+    T::Ort: Send + Sync + 'static,
 {
-    type Ort = Flavor<H::Ort, G::Ort>;
+    type Ort = Flavor<H::Ort, G::Ort, T::Ort>;
 
     async fn make_ort(&mut self, target: Target) -> Result<Self::Ort, Error> {
         match target {
@@ -170,20 +175,26 @@ where
                 let c = self.1.make_ort(t).await?;
                 Ok(Flavor::Grpc(c))
             }
+            Target::Tcp(t) => {
+                let c = self.2.make_ort(t).await?;
+                Ok(Flavor::Tcp(c))
+            }
         }
     }
 }
 
 #[async_trait::async_trait]
-impl<H, G> Ort for Flavor<H, G>
+impl<H, G, T> Ort for Flavor<H, G, T>
 where
     H: Ort + Send + Sync + 'static,
     G: Ort + Send + Sync + 'static,
+    T: Ort + Send + Sync + 'static,
 {
     async fn ort(&mut self, spec: Spec) -> Result<Reply, Error> {
         match self {
             Flavor::Http(h) => h.ort(spec).await,
             Flavor::Grpc(g) => g.ort(spec).await,
+            Flavor::Tcp(t) => t.ort(spec).await,
         }
     }
 }
@@ -198,36 +209,38 @@ impl FromStr for Target {
         match uri.scheme_str() {
             Some("grpc") | None => Ok(Target::Grpc(uri)),
             Some("http") => Ok(Target::Http(uri)),
-            Some(scheme) => Err(UnsupportedScheme(scheme.to_string()).into()),
-        }
-    }
-}
-
-impl AsRef<hyper::Uri> for Target {
-    fn as_ref(&self) -> &hyper::Uri {
-        match self {
-            Flavor::Http(h) => &h,
-            Flavor::Grpc(g) => &g,
+            Some("tcp") => {
+                let t = match uri.authority() {
+                    Some(a) => format!("{}:{}", a.host(), a.port_u16().unwrap_or(8090)),
+                    None => return Err(InvalidTarget(uri).into()),
+                };
+                Ok(Target::Tcp(t))
+            }
+            Some(_) => Err(InvalidTarget(uri).into()),
         }
     }
 }
 
 impl std::fmt::Display for Target {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.as_ref().fmt(f)
+        match self {
+            Flavor::Http(h) => h.fmt(f),
+            Flavor::Grpc(g) => g.fmt(f),
+            Flavor::Tcp(t) => t.fmt(f),
+        }
     }
 }
 
 #[derive(Debug)]
-struct UnsupportedScheme(String);
+struct InvalidTarget(hyper::Uri);
 
-impl std::fmt::Display for UnsupportedScheme {
+impl std::fmt::Display for InvalidTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Unsupported scheme: {}", self.0)
     }
 }
 
-impl std::error::Error for UnsupportedScheme {}
+impl std::error::Error for InvalidTarget {}
 
 // === parse_duration ===
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,7 @@ bytes = "0.5"
 ort-core = { path = "../core" }
 ort-grpc = { path = "../grpc" }
 ort-http = { path = "../http" }
+ort-tcp = { path = "../tcp" }
 rand = { version = "0.7", features = ["small_rng"] }
 structopt = "0.3"
 tokio = { version = "0.2", features = ["macros", "signal", "time"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ort-server"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Oliver Gould <ver@buoyant.io>"]
 edition = "2018"
 publish = false

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -15,8 +15,8 @@ use tokio::signal::{
 };
 
 #[derive(Clone, Debug, StructOpt)]
-#[structopt(about = "Load target")]
-pub struct Server {
+#[structopt(name = "server", about = "Load target")]
+pub struct Cmd {
     #[structopt(short, long, default_value = "0.0.0.0:8070")]
     grpc_addr: SocketAddr,
 
@@ -27,7 +27,7 @@ pub struct Server {
     tcp_addr: SocketAddr,
 }
 
-impl Server {
+impl Cmd {
     pub async fn run(self) -> Result<(), Box<dyn std::error::Error + 'static>> {
         let rng = SmallRng::from_entropy();
         let replier = Replier::new(rng);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,6 +5,7 @@ mod replier;
 use self::replier::Replier;
 use ort_grpc::server as grpc;
 use ort_http::server as http;
+use ort_tcp::server as tcp;
 use rand::{rngs::SmallRng, SeedableRng};
 use std::net::SocketAddr;
 use structopt::StructOpt;
@@ -21,8 +22,9 @@ pub struct Server {
 
     #[structopt(short, long, default_value = "0.0.0.0:8080")]
     http_addr: SocketAddr,
-    // #[structopt(short, long, default_value = "0.0.0.0:8090")]
-    // tcp_addr: SocketAddr,
+
+    #[structopt(short, long, default_value = "0.0.0.0:8090")]
+    tcp_addr: SocketAddr,
 }
 
 impl Server {
@@ -31,7 +33,8 @@ impl Server {
         let replier = Replier::new(rng);
 
         tokio::spawn(grpc::Server::new(replier.clone()).serve(self.grpc_addr));
-        tokio::spawn(http::Server::new(replier).serve(self.http_addr));
+        tokio::spawn(http::Server::new(replier.clone()).serve(self.http_addr));
+        tokio::spawn(tcp::Server::new(replier).serve(self.tcp_addr));
 
         let mut term = signal(SignalKind::terminate())?;
         tokio::select! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ struct Ort {
 
 #[derive(StructOpt)]
 enum Cmd {
-    Load(load::Opt),
-    Server(server::Server),
+    Load(load::Cmd),
+    Server(server::Cmd),
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     };
 
     match cmd {
-        Cmd::Load(l) => rt.block_on(l.run(threads)),
+        Cmd::Load(l) => rt.block_on(l.run()),
         Cmd::Server(s) => rt.block_on(s.run()),
     }
 }

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 publish = false
 
 [dependencies]
+async-trait = "0.1"
 bytes = "0.5"
 futures = "0.3"
-hyper = "0.13.3"
 ort-core = { path = "../core", features = ["deser"] }
 rand = { version = "0.7", features = ["small_rng"] }
 serde = "1.0"
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["io-util", "macros", "net", "signal", "time"] }
+tokio = { version = "0.2", features = ["io-util", "macros", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.3.1", features = ["codec"] }
 tracing = "0.1"

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ort-tcp"
+version = "0.1.0"
+authors = ["Oliver Gould <ver@buoyant.io>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+bytes = "0.5"
+futures = "0.3"
+hyper = "0.13.3"
+ort-core = { path = "../core", features = ["deser"] }
+rand = { version = "0.7", features = ["small_rng"] }
+serde = "1.0"
+serde_json = "1.0"
+tokio = { version = "0.2", features = ["io-util", "macros", "net", "signal", "time"] }
+tokio-util = { version = "0.3.1", features = ["codec"] }
+tracing = "0.1"

--- a/tcp/src/client.rs
+++ b/tcp/src/client.rs
@@ -1,0 +1,59 @@
+// XXX this doesn't really handle connection errors properly...
+
+use crate::{ReplyCodec, SpecCodec, PREFIX};
+use futures::prelude::*;
+use ort_core::{Error, MakeOrt, Ort, Reply, Spec};
+use std::sync::Arc;
+use tokio::{
+    net::{tcp, TcpStream},
+    prelude::*,
+    sync::Mutex,
+};
+use tokio_util::codec::{FramedRead, FramedWrite};
+
+#[derive(Clone)]
+pub struct MakeTcp {}
+
+#[derive(Clone)]
+pub struct Tcp(Arc<Mutex<Inner>>);
+
+struct Inner {
+    write: FramedWrite<tcp::OwnedWriteHalf, SpecCodec>,
+    read: FramedRead<tcp::OwnedReadHalf, ReplyCodec>,
+}
+
+impl MakeTcp {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl MakeOrt<String> for MakeTcp {
+    type Ort = Tcp;
+
+    async fn make_ort(&mut self, target: String) -> Result<Tcp, Error> {
+        let mut stream = TcpStream::connect(target).await?;
+        stream.set_nodelay(true)?;
+        stream.write(PREFIX.as_bytes()).await?;
+        let (read, write) = stream.into_split();
+        Ok(Tcp(Arc::new(Mutex::new(Inner {
+            write: FramedWrite::new(write, SpecCodec::default()),
+            read: FramedRead::new(read, ReplyCodec::default()),
+        }))))
+    }
+}
+
+#[async_trait::async_trait]
+impl Ort for Tcp {
+    async fn ort(&mut self, spec: Spec) -> Result<Reply, Error> {
+        let Inner {
+            ref mut read,
+            ref mut write,
+        } = *self.0.lock().await;
+        write.send(spec).await?;
+        read.try_next()
+            .await?
+            .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::NotConnected).into())
+    }
+}

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
+pub mod client;
 pub mod server;
 
 use bytes::BytesMut;
@@ -7,7 +8,8 @@ use ort_core::{Error, Reply, Spec};
 use serde_json as json;
 use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
-static PREFIX: &str = "ort.linkerd.io/load\r\n\r\n";
+const PREFIX_LEN: usize = 23;
+static PREFIX: &str = "ort.olix0r.net/load\r\n\r\n";
 
 struct SpecCodec(LengthDelimitedCodec);
 

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -1,0 +1,88 @@
+#![deny(warnings, rust_2018_idioms)]
+
+pub mod server;
+
+use bytes::BytesMut;
+use ort_core::{Error, Reply, Spec};
+use serde_json as json;
+use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
+
+static PREFIX: &str = "ort.linkerd.io/load\r\n\r\n";
+
+struct SpecCodec(LengthDelimitedCodec);
+
+struct ReplyCodec(LengthDelimitedCodec);
+
+// === impl SpecCodec ===
+
+impl Default for SpecCodec {
+    fn default() -> Self {
+        let frames = LengthDelimitedCodec::builder()
+            .max_frame_length(std::u32::MAX as usize)
+            .length_field_length(4)
+            .new_codec();
+        Self(frames)
+    }
+}
+
+impl Decoder for SpecCodec {
+    type Item = Spec;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Spec>, Error> {
+        match self.0.decode(src)? {
+            None => Ok(None),
+            Some(buf) => {
+                let spec = json::from_slice(buf.freeze().as_ref())?;
+                Ok(Some(spec))
+            }
+        }
+    }
+}
+
+impl Encoder<Spec> for SpecCodec {
+    type Error = Error;
+
+    fn encode(&mut self, spec: Spec, dst: &mut BytesMut) -> Result<(), Error> {
+        let buf = json::to_vec(&spec)?;
+        self.0.encode(buf.into(), dst)?;
+        Ok(())
+    }
+}
+
+// === impl ReplyCodec ===
+
+impl Default for ReplyCodec {
+    fn default() -> Self {
+        let frames = LengthDelimitedCodec::builder()
+            .max_frame_length(std::u32::MAX as usize)
+            .length_field_length(4)
+            .new_codec();
+        Self(frames)
+    }
+}
+
+impl Decoder for ReplyCodec {
+    type Item = Reply;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Reply>, Error> {
+        match self.0.decode(src)? {
+            None => Ok(None),
+            Some(buf) => {
+                let reply = json::from_slice(buf.freeze().as_ref())?;
+                Ok(Some(reply))
+            }
+        }
+    }
+}
+
+impl Encoder<Reply> for ReplyCodec {
+    type Error = Error;
+
+    fn encode(&mut self, reply: Reply, dst: &mut BytesMut) -> Result<(), Error> {
+        let buf = json::to_vec(&reply)?;
+        self.0.encode(buf.into(), dst)?;
+        Ok(())
+    }
+}

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -71,10 +71,7 @@ impl Decoder for ReplyCodec {
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Reply>, Error> {
         match self.0.decode(src)? {
             None => Ok(None),
-            Some(buf) => {
-                let reply = json::from_slice(buf.freeze().as_ref())?;
-                Ok(Some(reply))
-            }
+            Some(buf) => Ok(Some(Reply { data: buf.freeze() })),
         }
     }
 }
@@ -82,9 +79,8 @@ impl Decoder for ReplyCodec {
 impl Encoder<Reply> for ReplyCodec {
     type Error = Error;
 
-    fn encode(&mut self, reply: Reply, dst: &mut BytesMut) -> Result<(), Error> {
-        let buf = json::to_vec(&reply)?;
-        self.0.encode(buf.into(), dst)?;
+    fn encode(&mut self, Reply { data }: Reply, dst: &mut BytesMut) -> Result<(), Error> {
+        self.0.encode(data, dst)?;
         Ok(())
     }
 }

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -1,0 +1,67 @@
+use crate::{ReplyCodec, SpecCodec, PREFIX};
+use futures::prelude::*;
+use ort_core::{Error, Ort};
+use std::net::SocketAddr;
+use tokio::prelude::*;
+use tokio_util::codec::{FramedRead, FramedWrite};
+use tracing::info;
+
+pub struct Server<O>(O);
+
+impl<O: Ort> Server<O> {
+    pub fn new(inner: O) -> Self {
+        Self(inner)
+    }
+
+    pub async fn serve(self, addr: SocketAddr) -> Result<(), Error> {
+        let mut lis = tokio::net::TcpListener::bind(addr).await?;
+
+        loop {
+            let mut srv = self.0.clone();
+            let (mut stream, _addr) = lis.accept().await?;
+            tokio::spawn(async move {
+                let (mut sock_rx, sock_tx) = stream.split();
+
+                let mut prefix = Vec::<u8>::with_capacity(PREFIX.as_bytes().len());
+                let sz = match sock_rx.read_exact(prefix.as_mut()).await {
+                    Ok(sz) => sz,
+                    Err(error) => {
+                        info!(%error, "Could not read prefix");
+                        return;
+                    }
+                };
+
+                if sz != PREFIX.as_bytes().len() || prefix.as_slice() != PREFIX.as_bytes() {
+                    info!("Client isn't speaking our language");
+                    return;
+                }
+
+                let mut read = FramedRead::new(sock_rx, SpecCodec::default());
+                let mut write = FramedWrite::new(sock_tx, ReplyCodec::default());
+
+                loop {
+                    match read.next().await {
+                        None => return,
+                        Some(Err(error)) => {
+                            info!(%error, "Failed reading message");
+                            return;
+                        }
+                        Some(Ok(spec)) => {
+                            let reply = match srv.ort(spec).await {
+                                Ok(reply) => reply,
+                                Err(error) => {
+                                    info!(%error, "Failed replying");
+                                    return;
+                                }
+                            };
+                            if let Err(error) = write.send(reply).await {
+                                info!(%error, "Failed writing reply");
+                                return;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+}

--- a/templates/load.yml
+++ b/templates/load.yml
@@ -3,8 +3,8 @@
 {{- $services := int .Values.server.services | default 1}}
 {{- $load := .Values.load }}
 {{- $linkerd := deepCopy .Values.linkerd | merge $load.linkerd }}
-{{- range $proto, $port := .Values.protocols }}
-{{-   if $port }}
+{{- range $protoName, $proto := .Values.protocols }}
+{{-   if $proto}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -12,7 +12,7 @@ metadata:
   labels:
     app: ort
     ort.olix0r.net/role: load
-    ort.olix0r.net/protocol: {{ $proto }}
+    ort.olix0r.net/protocol: {{ $protoName }}
   name: load-{{ $proto }}
   namespace: {{ $ns }}
 spec:
@@ -21,13 +21,13 @@ spec:
     matchLabels:
       app: ort
       ort.olix0r.net/role: load
-      ort.olix0r.net/protocol: {{ $proto }}
+      ort.olix0r.net/protocol: {{ $protoName }}
   template:
     metadata:
       labels:
         app: ort
         ort.olix0r.net/role: load
-        ort.olix0r.net/protocol: {{ $proto }}
+        ort.olix0r.net/protocol: {{ $protoName }}
       annotations:
 {{ $linkerd | include "ort.linkerd" | indent 8 }}
     spec:
@@ -46,11 +46,12 @@ spec:
             - --threads={{ $load.threads }}
           {{- end }}
             - load
-          {{- range $f, $v := $load.flags }}
+          {{- $flags := deepCopy $proto.loadFlags | merge $load.flags }}
+          {{- range $f, $v := $flags }}
             - --{{ kebabcase $f }}={{ $v }}
           {{- end }}
           {{- range $i, $e := until $services }}
-            - {{ printf "%s://server-%03d:%d" $proto $i (int $port) }}
+            - {{ printf "%s://server-%03d:%d" $protoName $i (int $proto.port) }}
           {{- end }}
 {{-   end }}
 {{- end }}

--- a/templates/load.yml
+++ b/templates/load.yml
@@ -13,7 +13,7 @@ metadata:
     app: ort
     ort.olix0r.net/role: load
     ort.olix0r.net/protocol: {{ $protoName }}
-  name: load-{{ $proto }}
+  name: load-{{ $protoName }}
   namespace: {{ $ns }}
 spec:
   replicas: {{ int $load.replicas }}

--- a/templates/server.yml
+++ b/templates/server.yml
@@ -19,10 +19,10 @@ spec:
     ort.olix0r.net/role: server
     ort.olix0r.net/instance: {{quote $i}}
   ports:
-  {{- range $name, $port := $protocols }}
-  {{-   if $port }}
-    - port: {{ $port }}
-      targetPort: {{ $port }}
+  {{- range $name, $proto := $protocols }}
+  {{-   if $proto }}
+    - port: {{ $proto.port }}
+      targetPort: {{ $proto.port }}
       name: {{ $name }}
   {{-   end }}
   {{- end }}

--- a/templates/server.yml
+++ b/templates/server.yml
@@ -68,10 +68,10 @@ spec:
           {{- end }}
             - server
           ports:
-          {{- range $name, $port := $protocols }}
-          {{-   if $port }}
+          {{- range $name, $config := $protocols }}
+          {{-   if $config }}
             - protocol: TCP
-              containerPort: {{ $port }}
+              containerPort: {{ $config.port }}
               name: {{ $name }}
           {{-   end }}
           {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -3,8 +3,16 @@ image: ghcr.io/olix0r/ort:v0.1.8-1
 # # If the protocol ports are unset (or set to 0), then the load deployment won't be created and
 # the service won't expose the port.
 protocols:
-  grpc: 8070
-  http: 8080
+  grpc:
+    port: 8070
+    loadFlags: {}
+  http:
+    port: 8080
+    loadFlags: {}
+  tcp:
+    port: 8090
+    loadFlags:
+      clientsPerTarget: 3
 
 load:
   #log: info

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-image: ghcr.io/olix0r/ort:v0.1.8-1
+image: ghcr.io/olix0r/ort:v0.1.9
 
 # # If the protocol ports are unset (or set to 0), then the load deployment won't be created and
 # the service won't expose the port.


### PR DESCRIPTION
    The TCP load generator implements a simple JSON-oriented
    serial request-response protocol similar to the HTTP-based generators.
    This allows us to compare similar proxied traffic patterns without
    triggering HTTP protoco detection and HTTP-specific proxy logic.
    
    This `tcp::client` types don't implement reconnects, so further
    improvements are likely necessary.