### PR TITLE
viz: Provide a helm chart with prometheus & grafana

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1,4 +1,4 @@
-{{- define "ort.linkerd" -}}
+{{- define "ort.linkerd" }}
 linkerd.io/inject: {{ .inject | default "enabled" }}
 {{-   range $k, $v := .config }}
 {{-     if $v }}

--- a/chart/templates/load.yaml
+++ b/chart/templates/load.yaml
@@ -5,6 +5,7 @@
 {{- $linkerd := deepCopy .Values.linkerd | merge $load.linkerd }}
 {{- range $protoName, $proto := .Values.protocols }}
 {{-   if $proto.enabled }}
+{{-     $flags := deepCopy $proto.loadFlags | merge $load.flags }}
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -39,7 +40,11 @@ spec:
         ort.olix0r.net/role: load
         ort.olix0r.net/protocol: {{ $protoName }}
       annotations:
-{{ $linkerd | include "ort.linkerd" | indent 8 }}
+        ort.olix0r.net/threads: {{ quote $load.threads }}
+        {{- range $f, $v := $flags }}
+        ort.olix0r.net/{{ kebabcase $f }}: {{ quote $v }}
+        {{- end }}
+        {{- $linkerd | include "ort.linkerd" | indent 8 }}
     spec:
       serviceAccount: load-{{ $protoName }}
       containers:
@@ -57,10 +62,13 @@ spec:
             - --threads={{ $load.threads }}
           {{- end }}
             - load
-          {{- $flags := deepCopy $proto.loadFlags | merge $load.flags }}
           {{- range $f, $v := $flags }}
             - --{{ kebabcase $f }}={{ $v }}
           {{- end }}
             - {{ printf "%s://logical:%d" $protoName (int $proto.port) }}
+          ports:
+            - protocol: TCP
+              containerPort: 8000
+              name: admin-http
 {{-   end }}
 {{- end }}

--- a/chart/templates/server.yaml
+++ b/chart/templates/server.yaml
@@ -102,7 +102,7 @@ spec:
         ort.olix0r.net/role: server
         ort.olix0r.net/instance: {{ quote $i }}
       annotations:
-{{ $linkerd | include "ort.linkerd" | indent 8 }}
+        {{- $linkerd | include "ort.linkerd" | indent 8 }}
     spec:
       serviceAccount: {{ $name }}
       containers:
@@ -121,7 +121,9 @@ spec:
           {{- end }}
             - server
           {{- range $f, $v := $srv.flags }}
+          {{- if ne $f "adminAddr" }}
             - --{{ kebabcase $f }}={{ $v }}
+          {{- end }}
           {{- end }}
           ports:
           {{- range $name, $config := $protocols }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,23 +14,20 @@ protocols:
   tcp:
     enabled: false
     port: 8090
-    loadFlags:
-      requestsPerClient: 100
+    loadFlags: {}
 
 load:
-  #log: info
+  log: ort=debug
   replicas: 1
-  threads: 3
+  threads: 1
   linkerd: {}
-  flags: {}
-    #requestsPerClient: 1
-    #concurrencyLimit: 0
-    #requestLimit: 0
-    #requestLimitWindow: 1s
-    #responseSizes: 0=1024,100=1048576
+  flags:
+    concurrencyLimit: 1
+    requestLimit: 1
+    requestLimitWindow: 1s
 
 server:
-  #log: debug
+  log: ort=debug
   threads: 1
   services: 1
   replicas: 1

--- a/linkerd.yaml
+++ b/linkerd.yaml
@@ -1,0 +1,4 @@
+prometheus:
+  enabled: false
+grafana:
+  enabled: false

--- a/viz/Chart.yaml
+++ b/viz/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ort-viz
+description: Visibility for ort
+type: application
+version: 0.1.0
+appVersion: 0.7.0

--- a/viz/dashboards/ort.json
+++ b/viz/dashboards/ort.json
@@ -1,0 +1,2498 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "id": 1,
+    "iteration": 1607926501374,
+    "links": [],
+    "panels": [
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 8,
+            "panels": [],
+            "repeat": "protocol",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "title": "Load: $protocol",
+            "type": "row"
+        },
+        {
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null,
+                        "filterable": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 1
+            },
+            "id": 2,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.4",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "targets": [
+                {
+                    "expr": "sum(rate(response_latency_seconds_count{ort_role=\"load\",ort_protocol=\"$protocol\"}[$__rate_interval]))",
+                    "interval": "",
+                    "legendFormat": "{{pod}}",
+                    "refId": "B"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RPS",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null,
+                        "filterable": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 1,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 1
+            },
+            "hiddenSeries": false,
+            "id": 55,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(response_latency_ms_count{ort_role=\"load\",ort_protocol=\"$protocol\",direction=\"outbound\"}[$__rate_interval])) by (pod, dst_pod)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "responses from {{pod}} ",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "RPS",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "none",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "reqps",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(response_latency_seconds{ort_role=\"load\",ort_protocol=\"$protocol\",quantile!=\"1\"}) by (quantile, pod)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "{{quantile}} {{pod}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Response Latencies",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "s",
+                    "label": null,
+                    "logBase": 2,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 2,
+            "fillGradient": 2,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 6
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{ort_role=\"load\",ort_protocol=\"$protocol\",direction=\"outbound\"}[$__rate_interval])) by (le, pod, dst_pod))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "0.5 {{pod}} from {{dst_pod}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "histogram_quantile(0.90, sum(rate(response_latency_ms_bucket{ort_role=\"load\",ort_protocol=\"$protocol\",direction=\"outbound\"}[$__rate_interval])) by (le, pod, dst_pod))",
+                    "interval": "",
+                    "legendFormat": "0.9 {{pod}} from {{dst_pod}}",
+                    "refId": "B"
+                },
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{ort_role=\"load\",ort_protocol=\"$protocol\",direction=\"outbound\"}[$__rate_interval])) by (le, pod, dst_pod))",
+                    "interval": "",
+                    "legendFormat": "0.99 {{pod}} from {{dst_pod}}",
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Proxy Latencies",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": null,
+                    "logBase": 2,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 7,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 11
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "interval": "20s",
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(process_cpu_seconds_total{ort_role=\"load\",ort_protocol=\"$protocol\",job=\"proxy\"}[$__rate_interval])",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "20",
+                    "legendFormat": "{{pod}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Proxy CPU",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percentunit",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 1,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 11
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "process_resident_memory_bytes{ort_role=\"load\",ort_protocol=\"$protocol\"}",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "{{pod}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "(process_resident_memory_bytes - 12 * 1024 * 1024) / on(pod) sum(tcp_open_connections{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\"}) by (pod)",
+                    "hide": true,
+                    "interval": "",
+                    "legendFormat": "{{pod}} per connection",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Proxy RSS",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "decbytes",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 34,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(tcp_open_total{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"dst\"}[$__rate_interval])) by (pod, dst_pod)",
+                    "interval": "",
+                    "legendFormat": "connect {{pod}} to {{dst_pod}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "sum(rate(tcp_open_total{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"src\"}[$__rate_interval])) by (pod)",
+                    "interval": "",
+                    "legendFormat": "connect {{pod}} local",
+                    "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(tcp_close_total{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"dst\"}[$__rate_interval])) by (pod, dst_pod)",
+                    "interval": "",
+                    "legendFormat": "close {{pod}} from {{dst_pod}}",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(rate(tcp_close_total{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"src\"}[$__rate_interval])) by (pod)",
+                    "interval": "",
+                    "legendFormat": "close {{pod}} local",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP Connects",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 51,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "grpc",
+                    "value": "grpc"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(tcp_open_connections{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"src\"}) by (pod)",
+                    "interval": "",
+                    "legendFormat": "{{pod}} local",
+                    "refId": "A"
+                },
+                {
+                    "expr": "sum(tcp_open_connections{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"dst\"}) by (pod, dst_pod)",
+                    "interval": "",
+                    "legendFormat": "{{pod}} to {{dst_pod}}",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP Connections",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 21
+            },
+            "id": 57,
+            "panels": [],
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 8,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "title": "Load: $protocol",
+            "type": "row"
+        },
+        {
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null,
+                        "filterable": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 22
+            },
+            "id": 58,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.4",
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 2,
+            "repeatedByRow": true,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "targets": [
+                {
+                    "expr": "sum(rate(response_latency_seconds_count{ort_role=\"load\",ort_protocol=\"$protocol\"}[$__rate_interval]))",
+                    "interval": "",
+                    "legendFormat": "{{pod}}",
+                    "refId": "B"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RPS",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null,
+                        "filterable": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 1,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 22
+            },
+            "hiddenSeries": false,
+            "id": 59,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 55,
+            "repeatedByRow": true,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(response_latency_ms_count{ort_role=\"load\",ort_protocol=\"$protocol\",direction=\"outbound\"}[$__rate_interval])) by (pod, dst_pod)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "responses from {{pod}} ",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "RPS",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "none",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "reqps",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 27
+            },
+            "hiddenSeries": false,
+            "id": 60,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 4,
+            "repeatedByRow": true,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(response_latency_seconds{ort_role=\"load\",ort_protocol=\"$protocol\",quantile!=\"1\"}) by (quantile, pod)",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "{{quantile}} {{pod}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Response Latencies",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "s",
+                    "label": null,
+                    "logBase": 2,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 2,
+            "fillGradient": 2,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 27
+            },
+            "hiddenSeries": false,
+            "id": 61,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 3,
+            "repeatedByRow": true,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{ort_role=\"load\",ort_protocol=\"$protocol\",direction=\"outbound\"}[$__rate_interval])) by (le, pod, dst_pod))",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "0.5 {{pod}} from {{dst_pod}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "histogram_quantile(0.90, sum(rate(response_latency_ms_bucket{ort_role=\"load\",ort_protocol=\"$protocol\",direction=\"outbound\"}[$__rate_interval])) by (le, pod, dst_pod))",
+                    "interval": "",
+                    "legendFormat": "0.9 {{pod}} from {{dst_pod}}",
+                    "refId": "B"
+                },
+                {
+                    "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{ort_role=\"load\",ort_protocol=\"$protocol\",direction=\"outbound\"}[$__rate_interval])) by (le, pod, dst_pod))",
+                    "interval": "",
+                    "legendFormat": "0.99 {{pod}} from {{dst_pod}}",
+                    "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Proxy Latencies",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": null,
+                    "logBase": 2,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 7,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 62,
+            "interval": "20s",
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 5,
+            "repeatedByRow": true,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(process_cpu_seconds_total{ort_role=\"load\",ort_protocol=\"$protocol\",job=\"proxy\"}[$__rate_interval])",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "20",
+                    "legendFormat": "{{pod}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Proxy CPU",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percentunit",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 1,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 32
+            },
+            "hiddenSeries": false,
+            "id": 63,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 6,
+            "repeatedByRow": true,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "process_resident_memory_bytes{ort_role=\"load\",ort_protocol=\"$protocol\"}",
+                    "format": "time_series",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "{{pod}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "(process_resident_memory_bytes - 12 * 1024 * 1024) / on(pod) sum(tcp_open_connections{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\"}) by (pod)",
+                    "hide": true,
+                    "interval": "",
+                    "legendFormat": "{{pod}} per connection",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Proxy RSS",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "decbytes",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 37
+            },
+            "hiddenSeries": false,
+            "id": 64,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 34,
+            "repeatedByRow": true,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(tcp_open_total{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"dst\"}[$__rate_interval])) by (pod, dst_pod)",
+                    "interval": "",
+                    "legendFormat": "connect {{pod}} to {{dst_pod}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "sum(rate(tcp_open_total{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"src\"}[$__rate_interval])) by (pod)",
+                    "interval": "",
+                    "legendFormat": "connect {{pod}} local",
+                    "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(tcp_close_total{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"dst\"}[$__rate_interval])) by (pod, dst_pod)",
+                    "interval": "",
+                    "legendFormat": "close {{pod}} from {{dst_pod}}",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(rate(tcp_close_total{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"src\"}[$__rate_interval])) by (pod)",
+                    "interval": "",
+                    "legendFormat": "close {{pod}} local",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP Connects",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 37
+            },
+            "hiddenSeries": false,
+            "id": 65,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1607926501374,
+            "repeatPanelId": 51,
+            "repeatedByRow": true,
+            "scopedVars": {
+                "protocol": {
+                    "selected": false,
+                    "text": "http",
+                    "value": "http"
+                }
+            },
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(tcp_open_connections{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"src\"}) by (pod)",
+                    "interval": "",
+                    "legendFormat": "{{pod}} local",
+                    "refId": "A"
+                },
+                {
+                    "expr": "sum(tcp_open_connections{direction=\"outbound\",ort_role=\"load\",ort_protocol=\"$protocol\",peer=\"dst\"}) by (pod, dst_pod)",
+                    "interval": "",
+                    "legendFormat": "{{pod}} to {{dst_pod}}",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP Connections",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 42
+            },
+            "id": 16,
+            "title": "Servers",
+            "type": "row"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 43
+            },
+            "id": 24,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.4",
+            "repeat": null,
+            "targets": [
+                {
+                    "expr": "sum(rate(response_latency_ms_count{ort_role=\"server\"}[$__rate_interval]))",
+                    "interval": "",
+                    "legendFormat": "{{status_code}} {{pod}} from {{client_id}}",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total RPS",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 1,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 43
+            },
+            "hiddenSeries": false,
+            "id": 56,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(response_latency_ms_count{ort_role=\"server\"}[$__rate_interval])) by (status_code, pod, client_id)",
+                    "interval": "",
+                    "legendFormat": "{{status_code}} {{pod}} from {{client_id}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "RPS",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "none",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 3,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 48
+            },
+            "hiddenSeries": false,
+            "id": 25,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(process_cpu_seconds_total{ort_role=\"server\"}[$__rate_interval])",
+                    "interval": "",
+                    "legendFormat": "{{status_code}} {{pod}} {{client_id}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Proxy CPU",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percentunit",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 1,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 48
+            },
+            "hiddenSeries": false,
+            "id": 26,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "process_resident_memory_bytes{ort_role=\"server\"}",
+                    "interval": "",
+                    "legendFormat": "{{pod}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "(process_resident_memory_bytes - 12 * 1024 * 1024) / on(pod) sum(tcp_open_connections{direction=\"inbound\",ort_role=\"server\"}) by (pod)",
+                    "hide": true,
+                    "interval": "",
+                    "legendFormat": "{{pod}} per connection",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Proxy RSS",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "decbytes",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 53
+            },
+            "hiddenSeries": false,
+            "id": 52,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(rate(tcp_open_total{direction=\"inbound\",ort_role=\"server\",peer=\"src\"}[$__rate_interval])) by (pod, client_id)",
+                    "interval": "",
+                    "legendFormat": "connect {{pod}} from {{client_id}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "sum(rate(tcp_open_total{direction=\"inbound\",ort_role=\"server\",peer=\"dst\"}[$__rate_interval])) by (pod)",
+                    "interval": "",
+                    "legendFormat": "connect {{pod}} local",
+                    "refId": "B"
+                },
+                {
+                    "expr": "sum(rate(tcp_close_total{direction=\"inbound\",ort_role=\"server\",peer=\"src\"}[$__rate_interval])) by (pod, client_id)",
+                    "interval": "",
+                    "legendFormat": "close {{pod}} from {{client_id}}",
+                    "refId": "C"
+                },
+                {
+                    "expr": "sum(rate(tcp_close_total{direction=\"inbound\",ort_role=\"server\",peer=\"dst\"}[$__rate_interval])) by (pod)",
+                    "interval": "",
+                    "legendFormat": "close {{pod}} local",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP Connects",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 53
+            },
+            "hiddenSeries": false,
+            "id": 54,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.4",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum(tcp_open_connections{direction=\"inbound\",ort_role=\"server\",peer=\"src\"}) by (pod, client_id)",
+                    "interval": "",
+                    "legendFormat": "{{pod}} from {{client_id}}",
+                    "refId": "A"
+                },
+                {
+                    "expr": "sum(tcp_open_connections{direction=\"inbound\",ort_role=\"server\",peer=\"dst\"}) by (pod)",
+                    "interval": "",
+                    "legendFormat": "{{pod}} local",
+                    "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP Connections",
+            "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 26,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "prometheus",
+                "definition": "label_values(proxy_build_info, ort_protocol)",
+                "error": null,
+                "hide": 0,
+                "includeAll": true,
+                "label": "Protocol",
+                "multi": true,
+                "name": "protocol",
+                "options": [],
+                "query": "label_values(proxy_build_info, ort_protocol)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-15m",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Ort",
+    "uid": "hDSvgE0Gk",
+    "version": 1
+}

--- a/viz/templates/grafana.yaml
+++ b/viz/templates/grafana.yaml
@@ -1,0 +1,170 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: grafana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ort
+    ort.olix0r.net/role: grafana
+data:
+  grafana.ini: |-
+    instance_name = ort-grafana
+
+    [server]
+    root_url = %(protocol)s://%(domain)s:/
+
+    [auth]
+    disable_login_form = true
+
+    [auth.anonymous]
+    enabled = true
+    org_role = Editor
+
+    [auth.basic]
+    enabled = false
+
+    [analytics]
+    check_for_updates = false
+
+    [panels]
+    disable_sanitize_html = true
+
+  datasources.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: prometheus
+        type: prometheus
+        access: proxy
+        orgId: 1
+        url: http://prometheus:9090
+        isDefault: true
+        jsonData:
+          timeInterval: "5s"
+        version: 1
+        editable: true
+
+  dashboards.yaml: |-
+    apiVersion: 1
+    providers:
+      - name: 'default'
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: true
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards
+          homeDashboardId: ort
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ort
+    ort.olix0r.net/role: grafana
+data:
+{{ (.Files.Glob "dashboards/*.json").AsConfig | indent 2 }}
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: grafana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ort
+    ort.olix0r.net/role: grafana
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: grafana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ort
+    ort.olix0r.net/role: grafana
+spec:
+  type: LoadBalancer
+  selector:
+    app: ort
+    ort.olix0r.net/role: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ort
+    ort.olix0r.net/role: grafana
+  name: grafana
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ort
+      ort.olix0r.net/role: grafana
+  template:
+    metadata:
+      labels:
+        app: ort
+        ort.olix0r.net/role: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: {{ .Values.grafana.image }}
+          env:
+            - name: GF_PATHS_DATA
+              value: /data
+            # Force using the go-based DNS resolver instead of the OS' to avoid failures in some environments
+            # see https://github.com/grafana/grafana/issues/20096
+            - name: GODEBUG
+              value: netdns=go
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 30
+          ports:
+            - containerPort: 3000
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+          securityContext:
+            runAsUser: 472
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+            - name: etc-grafana
+              mountPath: /etc/grafana
+              readOnly: true
+      serviceAccountName: grafana
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: etc-grafana
+          configMap:
+            name: grafana
+            items:
+              - key: grafana.ini
+                path: grafana.ini
+              - key: datasources.yaml
+                path: provisioning/datasources/datasources.yaml
+              - key: dashboards.yaml
+                path: provisioning/dashboards/dashboards.yaml
+        - name: dashboards
+          configMap:
+            name: dashboards
+            items:
+              - key: ort.json
+                path: ort.json

--- a/viz/templates/prometheus.yaml
+++ b/viz/templates/prometheus.yaml
@@ -1,0 +1,198 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ort-prometheus
+  labels:
+    app: ort
+    ort.olix0r.net/role: prometheus
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "nodes/proxy", "pods"]
+  verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ort-prometheus
+  labels:
+    app: ort
+    ort.olix0r.net/role: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ort-prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ort
+    ort.olix0r.net/role: prometheus
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ort
+    ort.olix0r.net/role: prometheus
+data:
+  prometheus.yml: |-
+    {{- if .Values.prometheus.globalConfig }}
+    global:
+      {{- toYaml .Values.prometheus.globalConfig | trim | nindent 6 }}
+    {{- end}}
+    scrape_configs:
+      - job_name: 'ort-load'
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: ['{{ .Values.namespace }}']
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_pod_label_ort_olix0r_net_role
+              - __meta_kubernetes_pod_container_port_name
+            action: keep
+            regex: ^load;admin-http$
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_annotation_linkerd_io_proxy_version]
+            action: replace
+            target_label: proxy_version
+          - source_labels: [__meta_kubernetes_pod_label_ort_olix0r_net_role]
+            action: replace
+            target_label: ort_role
+          - source_labels: [__meta_kubernetes_pod_label_ort_olix0r_net_protocol]
+            action: replace
+            target_label: ort_protocol
+          - source_labels: [__meta_kubernetes_pod_annotation_ort_olix0r_net_threads]
+            action: replace
+            target_label: ort_threads
+          - source_labels: [__meta_kubernetes_pod_annotation_ort_olix0r_net_request_limit]
+            action: replace
+            target_label: ort_request_limit
+          - source_labels: [__meta_kubernetes_pod_annotation_ort_olix0r_net_concurrency_limit]
+            action: replace
+            target_label: ort_concurrency_limit
+      - job_name: 'proxy'
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: ['{{ .Values.namespace }}']
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_pod_container_name
+              - __meta_kubernetes_pod_container_port_name
+            action: keep
+            regex: ^linkerd-proxy;linkerd-admin$
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_annotation_linkerd_io_proxy_version]
+            action: replace
+            target_label: proxy_version
+          - source_labels: [__meta_kubernetes_pod_label_ort_olix0r_net_role]
+            action: replace
+            target_label: ort_role
+          - source_labels: [__meta_kubernetes_pod_label_ort_olix0r_net_protocol]
+            action: replace
+            target_label: ort_protocol
+          - source_labels: [__meta_kubernetes_pod_annotation_ort_olix0r_net_threads]
+            action: replace
+            target_label: ort_threads
+          - source_labels: [__meta_kubernetes_pod_annotation_ort_olix0r_net_request_limit]
+            action: replace
+            target_label: ort_request_limit
+          - source_labels: [__meta_kubernetes_pod_annotation_ort_olix0r_net_concurrency_limit]
+            action: replace
+            target_label: ort_concurrency_limit
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ort
+    ort.olix0r.net/role: prometheus
+spec:
+  type: LoadBalancer
+  selector:
+    app: ort
+    ort.olix0r.net/role: prometheus
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ort
+    ort.olix0r.net/role: prometheus
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ort
+      ort.olix0r.net/role: prometheus
+  template:
+    metadata:
+      labels:
+        app: ort
+        ort.olix0r.net/role: prometheus
+    spec:
+      securityContext:
+        fsGroup: 65534
+      containers:
+      - args:
+        {{- range $key, $value := .Values.prometheus.flags }}
+        - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+        {{- end }}
+        image: {{ .Values.prometheus.image }}
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9090
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9090
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+          runAsGroup: 65534
+        volumeMounts:
+        - mountPath: /data
+          name: data
+        - mountPath: /etc/prometheus/prometheus.yml
+          name: prometheus
+          subPath: prometheus.yml
+          readOnly: true
+      serviceAccountName: prometheus
+      volumes:
+      - name: data
+        emptyDir: {}
+      - configMap:
+          name: prometheus
+        name: prometheus

--- a/viz/values.yaml
+++ b/viz/values.yaml
@@ -1,0 +1,16 @@
+namespace: ort
+
+grafana:
+  image: docker.io/grafana/grafana:7.3.4
+
+prometheus:
+  image: docker.io/prom/prometheus:v2.23.0
+  flags:
+    storage.tsdb.path: /data
+    storage.tsdb.retention.time: 1w
+    config.file: /etc/prometheus/prometheus.yml
+    log.level: info
+  globalConfig:
+    scrape_interval: 10s
+    scrape_timeout: 10s
+    evaluation_interval: 10s


### PR DESCRIPTION
This change adds a default grafana dashboard that can be used to
understand an Ort topology.