### PR TITLE
Replace structopt with clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,17 +122,32 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b1121e32687f7f90b905d4775273305baa4f32cd418923e9b0fa726533221857"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -582,11 +597,11 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 name = "ort"
 version = "0.2.11"
 dependencies = [
+ "clap",
  "jemallocator",
  "num_cpus",
  "ort-load",
  "ort-server",
- "structopt",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -642,6 +657,7 @@ version = "0.2.11"
 dependencies = [
  "anyhow",
  "async-trait",
+ "clap",
  "futures",
  "http",
  "hyper",
@@ -652,7 +668,6 @@ dependencies = [
  "ort-tcp",
  "parking_lot",
  "rand",
- "structopt",
  "tokio",
  "tracing",
 ]
@@ -663,6 +678,7 @@ version = "0.2.11"
 dependencies = [
  "async-trait",
  "bytes",
+ "clap",
  "drain",
  "futures",
  "hyper",
@@ -671,7 +687,6 @@ dependencies = [
  "ort-http",
  "ort-tcp",
  "rand",
- "structopt",
  "tokio",
  "tonic",
  "tracing",
@@ -689,6 +704,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1017,33 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1071,13 +1071,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thread_local"
@@ -1313,22 +1319,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1378,6 +1372,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ default = []
 grpc-fmt = ["ort-load/grpc-fmt", "ort-server/grpc-fmt"]
 
 [dependencies]
+clap = { version = "3", features = ["derive"] }
 num_cpus = "1"
 ort-load = { version = "0.2", path = "./load" }
 ort-server = { version = "0.2", path = "./server" }
-structopt = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -3,19 +3,20 @@
 The project consists of a client and server that are ready to be deployed in
 Kubernetes, especially for testing [Linkerd](https://linkerd.io).
 
-```
+```text
 ort 0.2.11
 Load harness
 
 USAGE:
-    ort <SUBCOMMAND>
+    ort [OPTIONS] <SUBCOMMAND>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+OPTIONS:
+    -h, --help                 Print help information
+        --threads <THREADS>    
+    -V, --version              Print version information
 
 SUBCOMMANDS:
-    help      Prints this message or the help of the given subcommand(s)
+    help      Print this message or the help of the given subcommand(s)
     load      Load generator
     server    Load target
 ```

--- a/load/Cargo.toml
+++ b/load/Cargo.toml
@@ -12,6 +12,7 @@ grpc-fmt = ["ort-grpc/rustfmt"]
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+clap = { version = "3", features = ["derive"] }
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 hyper = { version = "0.14", default-features = false }
@@ -22,6 +23,5 @@ ort-tcp = { version = "0.2", path = "../tcp" }
 linkerd-metrics = { git = "https://github.com/linkerd/linkerd2-proxy", branch = "main", features = ["summary"] }
 parking_lot = "0.11"
 rand = "0.8"
-structopt = "0.3"
 tokio = { version = "1", features = ["macros", "signal", "sync", "time"] }
 tracing = "0.1"

--- a/load/src/lib.rs
+++ b/load/src/lib.rs
@@ -12,12 +12,12 @@ use self::{
     runner::Runner, timeout::MakeRequestTimeout,
 };
 use anyhow::{anyhow, bail, Result};
+use clap::Parser;
 use ort_core::{latency, parse_duration, Distribution, Error, MakeOrt, Ort, Reply, Spec};
 use ort_grpc::client::MakeGrpc;
 use ort_http::client::MakeHttp;
 use ort_tcp::client::MakeTcp;
 use std::{fmt::Debug, net::SocketAddr, str::FromStr, sync::Arc};
-use structopt::StructOpt;
 use tokio::{
     signal::{
         ctrl_c,
@@ -27,61 +27,61 @@ use tokio::{
 };
 use tracing::{debug_span, info, Instrument};
 
-#[derive(StructOpt)]
-#[structopt(name = "load", about = "Load generator")]
+#[derive(Parser)]
+#[clap(name = "load", about = "Load generator")]
 pub struct Cmd {
-    #[structopt(long, parse(try_from_str), default_value = "0.0.0.0:8000")]
+    #[clap(long, parse(try_from_str), default_value = "0.0.0.0:8000")]
     admin_addr: SocketAddr,
 
-    #[structopt(long)]
+    #[clap(long)]
     clients: Option<usize>,
 
-    #[structopt(long)]
+    #[clap(long)]
     concurrency_limit_init: Option<usize>,
 
-    #[structopt(long, parse(try_from_str = parse_duration), default_value = "0s")]
+    #[clap(long, parse(try_from_str = parse_duration), default_value = "0s")]
     concurrency_limit_ramp_period: Duration,
 
-    #[structopt(long, default_value = "1")]
+    #[clap(long, default_value = "1")]
     concurrency_limit_ramp_step: usize,
 
-    #[structopt(long)]
+    #[clap(long)]
     concurrency_limit_ramp_reset: bool,
 
-    #[structopt(long)]
+    #[clap(long)]
     concurrency_limit: Option<usize>,
 
-    #[structopt(long)]
+    #[clap(long)]
     request_limit_init: Option<usize>,
 
-    #[structopt(long, parse(try_from_str = parse_duration), default_value = "0s")]
+    #[clap(long, parse(try_from_str = parse_duration), default_value = "0s")]
     request_limit_ramp_period: Duration,
 
-    #[structopt(long, default_value = "1")]
+    #[clap(long, default_value = "1")]
     request_limit_ramp_step: usize,
 
-    #[structopt(long)]
+    #[clap(long)]
     request_limit_ramp_reset: bool,
 
-    #[structopt(long, default_value = "0")]
+    #[clap(long, default_value = "0")]
     request_limit: usize,
 
-    #[structopt(long, parse(try_from_str = parse_duration), default_value = "1s")]
+    #[clap(long, parse(try_from_str = parse_duration), default_value = "1s")]
     request_limit_window: Duration,
 
-    #[structopt(long, parse(try_from_str = parse_duration), default_value = "10s")]
+    #[clap(long, parse(try_from_str = parse_duration), default_value = "10s")]
     request_timeout: Duration,
 
-    #[structopt(long, parse(try_from_str = parse_duration), default_value = "1s")]
+    #[clap(long, parse(try_from_str = parse_duration), default_value = "1s")]
     connect_timeout: Duration,
 
-    #[structopt(long)]
+    #[clap(long)]
     total_requests: Option<usize>,
 
-    #[structopt(long, default_value = "0")]
+    #[clap(long, default_value = "0")]
     response_latency: latency::Distribution,
 
-    #[structopt(long, default_value = "0")]
+    #[clap(long, default_value = "0")]
     response_size: Distribution,
 
     target: Target,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,6 +12,7 @@ grpc-fmt = ["ort-grpc/rustfmt"]
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
+clap = { version = "3", features = ["derive"] }
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
 hyper = { version = "0.14", default-features = false, features = ["http1", "server", "tcp"] }
@@ -20,7 +21,6 @@ ort-grpc = { version = "0.2", path = "../grpc", features = ["server"] }
 ort-http = { version = "0.2", path = "../http" }
 ort-tcp = { version = "0.2", path = "../tcp" }
 rand =  "0.8"
-structopt = "0.3"
 tokio = { version = "1", features = ["macros", "signal", "time"] }
 tonic = { version = "0.6", default-features = false }
 tracing = "0.1"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,34 +3,34 @@
 mod replier;
 
 use self::replier::Replier;
+use clap::Parser;
 use ort_core::latency;
 use ort_grpc::server as grpc;
 use ort_http::server as http;
 use ort_tcp::server as tcp;
 use std::net::SocketAddr;
-use structopt::StructOpt;
 use tokio::signal::{
     ctrl_c,
     unix::{signal, SignalKind},
 };
 use tracing::{debug, info_span, instrument, Instrument};
 
-#[derive(StructOpt)]
-#[structopt(name = "server", about = "Load target")]
+#[derive(Parser)]
+#[clap(name = "server", about = "Load target")]
 pub struct Cmd {
-    #[structopt(short, long, default_value = "0.0.0.0:9090")]
+    #[clap(short, long, default_value = "0.0.0.0:9090")]
     admin_addr: SocketAddr,
 
-    #[structopt(short, long, default_value = "0.0.0.0:8070")]
+    #[clap(short, long, default_value = "0.0.0.0:8070")]
     grpc_addr: SocketAddr,
 
-    #[structopt(short, long, default_value = "0.0.0.0:8080")]
+    #[clap(short, long, default_value = "0.0.0.0:8080")]
     http_addr: SocketAddr,
 
-    #[structopt(short, long, default_value = "0.0.0.0:8090")]
+    #[clap(short, long, default_value = "0.0.0.0:8090")]
     tcp_addr: SocketAddr,
 
-    #[structopt(long, default_value = "0")]
+    #[clap(long, default_value = "0")]
     response_latency: latency::Distribution,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,25 @@
 #![deny(warnings, rust_2018_idioms)]
 
+use clap::Parser;
 use ort_load as load;
 use ort_server as server;
-use structopt::StructOpt;
 use tokio::runtime as rt;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[derive(StructOpt)]
-#[structopt(about = "Load harness")]
+#[derive(Parser)]
+#[clap(about = "Load harness", version)]
 struct Ort {
     #[structopt(long)]
     threads: Option<usize>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: Cmd,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 enum Cmd {
     Load(load::Cmd),
     Server(server::Cmd),
@@ -28,7 +28,7 @@ enum Cmd {
 fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     tracing_subscriber::fmt::init();
 
-    let Ort { threads, cmd } = Ort::from_args();
+    let Ort { threads, cmd } = Ort::parse();
 
     let threads = threads.unwrap_or_else(num_cpus::get);
     let rt = rt::Builder::new_multi_thread()


### PR DESCRIPTION
The new version of `clap` replaces the need for `structopt`.